### PR TITLE
Add more derives for geng::Event

### DIFF
--- a/crates/geng/src/camera/camera_2d.rs
+++ b/crates/geng/src/camera/camera_2d.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 /// 2-dimensional camera.
 pub struct Camera2d {
     pub center: vec2<f32>,

--- a/crates/geng/src/window/events/mod.rs
+++ b/crates/geng/src/window/events/mod.rs
@@ -15,12 +15,12 @@ pub enum MouseButton {
     Right,
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TouchPoint {
     pub position: vec2<f64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Event {
     MouseDown {
         position: vec2<f64>,

--- a/crates/geng/src/window/events/mod.rs
+++ b/crates/geng/src/window/events/mod.rs
@@ -15,12 +15,12 @@ pub enum MouseButton {
     Right,
 }
 
-#[derive(Debug, Copy, Clone, Serialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct TouchPoint {
     pub position: vec2<f64>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Event {
     MouseDown {
         position: vec2<f64>,

--- a/crates/geng/src/window/events/mod.rs
+++ b/crates/geng/src/window/events/mod.rs
@@ -8,19 +8,19 @@ mod impl_web;
 #[path = "native.rs"]
 mod _impl;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum MouseButton {
     Left,
     Middle,
     Right,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Serialize)]
 pub struct TouchPoint {
     pub position: vec2<f64>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub enum Event {
     MouseDown {
         position: vec2<f64>,


### PR DESCRIPTION
Adds `#[derive(PartialEq, Serialize, Deserialize)]` to `geng::Event` (and `geng::TouchPoint` and `geng::MouseButton`)